### PR TITLE
Correcting typo in export_res.rst

### DIFF
--- a/docs/source/documentation/cgmlst/export_res.rst
+++ b/docs/source/documentation/cgmlst/export_res.rst
@@ -71,7 +71,7 @@ can be defined.
 
 .. code-block:: bash
 				
-   wgMLST mslt --help
+   wgMLST mlst --help
    Usage: wgMLST mlst [OPTIONS] DATABASE
 
    Extracts an MLST table from a wgMLST DATABASE.


### PR DESCRIPTION
Correcting typo mslt  -> mlst