### PR TITLE
Add pasteur repository to classical MLST search

### DIFF
--- a/docs/source/documentation/clamlst/initialise.rst
+++ b/docs/source/documentation/clamlst/initialise.rst
@@ -16,7 +16,7 @@ Import from pubMLST
 ===================
 
 You can automatically import a MLST resource from `pubmlst
-<https://pubmlst.org/data/>`_.
+<https://pubmlst.org/data/>`_ or `pasteur <https://bigsdb.pasteur.fr/>`_.
 
 .. code-block:: bash
 
@@ -32,6 +32,8 @@ You can automatically import a MLST resource from `pubmlst
 				           fail instead.
    -f, --force        	   Overwrites alrealdy existing DATABASE
    -m, --mlst TEXT         Specifies the desired MLST scheme name.
+   -r, --repository        Choose the online repository to use [pubmlst|pasteur]
+
 
 
 Create from other resource

--- a/pymlst/cla/commands/import.py
+++ b/pymlst/cla/commands/import.py
@@ -27,6 +27,12 @@ from pymlst.common import utils
               type=click.STRING,
               default='',
               help='Specifies the desired MLST scheme name.')
+@click.option('--repository', '-r', default='pubmlst', 
+              type=click.Choice(['pubmlst','pasteur'], case_sensitive=False),
+              help='Choose the online repository to use')
+# @click.option('--pubmlst/--pasteur',
+#               default=True, show_default="pubmlst", 
+#               help= "Choose the online repository")
 @click.argument('database',
                 type=click.Path(exists=False))
 @click.argument('species',
@@ -34,7 +40,7 @@ from pymlst.common import utils
                 nargs=-1)
 
 
-def cli(force, prompt, mlst, database, species):
+def cli(force, prompt, mlst, repository, database, species):
     """Creates a claMLST DATABASE from an online resource.
 
     The research can be filtered by adding a SPECIES name."""
@@ -49,7 +55,7 @@ def cli(force, prompt, mlst, database, species):
             else:
                 raise exceptions.PyMLSTError("Database alreadly exists, use --force to override it")
 
-        url = web.retrieve_mlst(' '.join(species), prompt, mlst)
+        url = web.retrieve_mlst(' '.join(species), prompt, mlst, repository)
 
         if url is None:
             logging.info('No choice selected')

--- a/pymlst/cla/core.py
+++ b/pymlst/cla/core.py
@@ -248,7 +248,7 @@ class ClassicalMLST:
         with self.database.begin():
             # Verify sheme list with fasta files
             header = scheme.readline().rstrip("\n").split("\t")
-            if len(header) != len(alleles) + 1:
+            if len(header) < len(alleles) + 1:
                 raise Exception("The number of genes in sheme don't "
                                 "correspond to the number of fasta file\n"
                                 + " ".join(header) + "\n")
@@ -282,7 +282,8 @@ class ClassicalMLST:
             for line in scheme:
                 line_content = line.rstrip("\n").split("\t")
                 sequence_typing = int(line_content[0])
-                for gene, allele in zip(header[1:], line_content[1:]):
+                for gene, allele in zip(header[1:len(fastas)+1], \
+                                        line_content[1:len(fastas)+1]):
                     if int(allele) not in alleles.get(gene):
                         logging.warning(
                             "Unable to find the allele number %s"


### PR DESCRIPTION
Add **pasteur** MLST repositry to _import_ command.
Change the filtering of supplementary column on profiles to be apply to _import_ or _create_ command. 